### PR TITLE
Refactors API authentication to use Axum extractor

### DIFF
--- a/server/src/api/auth_extractor.rs
+++ b/server/src/api/auth_extractor.rs
@@ -1,0 +1,247 @@
+use crate::oauth::auth::Claims;
+use axum::{
+    async_trait,
+    extract::FromRequestParts,
+    http::{header, request::Parts, StatusCode},
+};
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    pub user_id: Uuid,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+}
+
+impl From<Claims> for AuthenticatedUser {
+    fn from(claims: Claims) -> Self {
+        Self {
+            user_id: Uuid::parse_str(&claims.sub).unwrap_or_default(),
+            client_id: claims.client_id,
+            scopes: claims.scopes,
+        }
+    }
+}
+
+#[async_trait]
+impl FromRequestParts<crate::api::AppState> for AuthenticatedUser {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::api::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Get Authorization header
+        let auth_header = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        // Extract Bearer token
+        let token = auth_header
+            .strip_prefix("Bearer ")
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        // Verify token and get claims using the state directly
+        let claims = state
+            .oauth_service
+            .verify_access_token(token)
+            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+
+        // Convert claims to AuthenticatedUser
+        Ok(AuthenticatedUser::from(claims))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::AppState;
+    use crate::oauth::auth::OAuthService;
+    use crate::oauth::storage::OAuthStorage;
+    use crate::storage::StorageEngine;
+    use axum::http::Request;
+    use chrono::{Duration, Utc};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    async fn setup_test_state() -> (AppState, TempDir, String) {
+        let temp_dir = TempDir::new().unwrap();
+        let data_root = temp_dir.path().to_path_buf();
+
+        let storage = Arc::new(StorageEngine::new(data_root.clone()).await.unwrap());
+        let oauth_storage = Arc::new(OAuthStorage::new(data_root.clone()).await.unwrap());
+
+        // Use a test JWT secret
+        std::env::set_var("JWT_SECRET", "test_secret_for_unit_tests");
+        let oauth_service = Arc::new(OAuthService::new(oauth_storage.clone()));
+
+        let state = AppState {
+            storage,
+            oauth_storage,
+            oauth_service,
+        };
+
+        (state, temp_dir, "test_secret_for_unit_tests".to_string())
+    }
+
+    fn create_test_token(secret: &str, expired: bool, wrong_secret: bool) -> String {
+        let now = Utc::now();
+        let exp = if expired {
+            (now - Duration::hours(2)).timestamp()
+        } else {
+            (now + Duration::hours(1)).timestamp()
+        };
+
+        let claims = Claims {
+            sub: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            client_id: "test_client".to_string(),
+            scopes: vec!["read".to_string(), "write".to_string()],
+            exp,
+            iat: now.timestamp(),
+        };
+
+        let secret_to_use = if wrong_secret { "wrong_secret" } else { secret };
+
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret_to_use.as_ref()),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_valid_jwt_extraction() {
+        let (state, _temp, secret) = setup_test_state().await;
+        let token = create_test_token(&secret, false, false);
+
+        // Test by directly extracting from request parts
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {}", token))
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+
+        // Extract AuthenticatedUser directly
+        let user = AuthenticatedUser::from_request_parts(&mut parts, &state)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            user.user_id.to_string(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(user.client_id, "test_client");
+        assert_eq!(user.scopes, vec!["read", "write"]);
+    }
+
+    #[tokio::test]
+    async fn test_missing_authorization_header() {
+        let (state, _temp, _) = setup_test_state().await;
+
+        let request = Request::builder().uri("/test").body(()).unwrap();
+
+        let (mut parts, _) = request.into_parts();
+
+        // Try to extract AuthenticatedUser without auth header
+        let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_malformed_authorization_header() {
+        let (state, _temp, _) = setup_test_state().await;
+
+        // Test with missing "Bearer " prefix
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, "invalid_token")
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+        let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+
+        // Test with wrong auth scheme
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, "Basic dXNlcjpwYXNz")
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+        let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_expired_jwt() {
+        let (state, _temp, secret) = setup_test_state().await;
+        let expired_token = create_test_token(&secret, true, false);
+
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {}", expired_token))
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+        let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_jwt_with_wrong_signature() {
+        let (state, _temp, secret) = setup_test_state().await;
+        let wrong_sig_token = create_test_token(&secret, false, true);
+
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {}", wrong_sig_token))
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+        let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_user_extraction() {
+        let (state, _temp, secret) = setup_test_state().await;
+        let token = create_test_token(&secret, false, false);
+
+        let request = Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, format!("Bearer {}", token))
+            .body(())
+            .unwrap();
+
+        let (mut parts, _) = request.into_parts();
+        let user = AuthenticatedUser::from_request_parts(&mut parts, &state)
+            .await
+            .unwrap();
+
+        // Verify the extracted data
+        assert_eq!(
+            user.user_id.to_string(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(user.client_id, "test_client");
+        assert_eq!(user.scopes, vec!["read", "write"]);
+    }
+}

--- a/server/src/api/handlers.rs
+++ b/server/src/api/handlers.rs
@@ -6,7 +6,11 @@ use axum::{
 };
 use bytes::Bytes;
 
-use crate::{api::AppState, error::Result, storage::FileType};
+use crate::{
+    api::{AppState, AuthenticatedUser},
+    error::Result,
+    storage::FileType,
+};
 
 pub async fn health_check() -> impl IntoResponse {
     Json(serde_json::json!({
@@ -15,6 +19,7 @@ pub async fn health_check() -> impl IntoResponse {
 }
 
 pub async fn get_resource(
+    _user: AuthenticatedUser,
     Path(path): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Response> {
@@ -39,6 +44,7 @@ pub async fn get_resource(
 }
 
 pub async fn head_resource(
+    _user: AuthenticatedUser,
     Path(path): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Response> {
@@ -69,6 +75,7 @@ pub async fn head_resource(
 }
 
 pub async fn put_file(
+    _user: AuthenticatedUser,
     Path(path): Path<String>,
     State(state): State<AppState>,
     body: Bytes,
@@ -87,6 +94,7 @@ pub async fn put_file(
 }
 
 pub async fn create_directory(
+    _user: AuthenticatedUser,
     Path(path): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Response> {
@@ -98,6 +106,7 @@ pub async fn create_directory(
 }
 
 pub async fn delete_resource(
+    _user: AuthenticatedUser,
     Path(path): Path<String>,
     State(state): State<AppState>,
 ) -> Result<Response> {

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -1,11 +1,12 @@
+pub mod auth_extractor;
 pub mod handlers;
 pub mod oauth_handlers;
 pub mod state;
 
+pub use auth_extractor::AuthenticatedUser;
 pub use state::AppState;
 
 use axum::{
-    middleware,
     routing::{delete, get, head, post, put},
     Router,
 };
@@ -31,17 +32,13 @@ pub fn create_router(state: AppState) -> Router {
         )
         .with_state(state.clone());
 
-    // Create protected API routes
+    // Create protected API routes (AuthenticatedUser extractor handles auth per-handler)
     let protected_routes = Router::new()
         .route("/*path", get(handlers::get_resource))
         .route("/*path", head(handlers::head_resource))
         .route("/*path", put(handlers::put_file))
         .route("/*path", post(handlers::create_directory))
         .route("/*path", delete(handlers::delete_resource))
-        .layer(middleware::from_fn_with_state(
-            state.clone(),
-            oauth_handlers::auth_middleware,
-        ))
         .with_state(state.clone());
 
     // Combine routes

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -1,0 +1,66 @@
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestClaims {
+    pub sub: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub exp: i64,
+    pub iat: i64,
+}
+
+/// Generate a valid JWT token for testing
+pub fn generate_test_token() -> String {
+    generate_test_token_with_options("test-user-id", "test-client", vec!["read", "write"], false)
+}
+
+/// Generate a JWT token with custom options
+pub fn generate_test_token_with_options(
+    user_id: &str,
+    client_id: &str,
+    scopes: Vec<&str>,
+    expired: bool,
+) -> String {
+    let now = Utc::now();
+    let exp = if expired {
+        (now - Duration::hours(2)).timestamp()
+    } else {
+        (now + Duration::hours(1)).timestamp()
+    };
+
+    // Ensure user_id is a valid UUID string
+    let user_id = if let Ok(uuid) = Uuid::parse_str(user_id) {
+        uuid.to_string()
+    } else {
+        // Use a default UUID if the provided one is invalid
+        Uuid::new_v4().to_string()
+    };
+
+    let claims = TestClaims {
+        sub: user_id,
+        client_id: client_id.to_string(),
+        scopes: scopes.iter().map(|s| s.to_string()).collect(),
+        exp,
+        iat: now.timestamp(),
+    };
+
+    // Use the same secret as the test environment
+    let secret = std::env::var("JWT_SECRET")
+        .unwrap_or_else(|_| "development_secret_change_in_production".to_string());
+
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_ref()),
+    )
+    .unwrap()
+}
+
+/// Create an Authorization header value with a Bearer token
+#[allow(dead_code)]
+pub fn auth_header(token: &str) -> (&'static str, String) {
+    ("authorization", format!("Bearer {}", token))
+}

--- a/server/tests/integration_auth.rs
+++ b/server/tests/integration_auth.rs
@@ -1,0 +1,333 @@
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use server::{
+    api::{self, AppState},
+    oauth::{auth::OAuthService, storage::OAuthStorage},
+    storage::StorageEngine,
+};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+mod common;
+
+async fn setup_test_app() -> (axum::Router, TempDir, String) {
+    let temp_dir = TempDir::new().unwrap();
+    let data_root = temp_dir.path().to_path_buf();
+
+    let storage = Arc::new(StorageEngine::new(data_root.clone()).await.unwrap());
+    let oauth_storage = Arc::new(OAuthStorage::new(data_root.clone()).await.unwrap());
+    let oauth_service = Arc::new(OAuthService::new(oauth_storage.clone()));
+
+    // Create a test user and client for authenticated tests
+    oauth_storage
+        .create_user(
+            "testuser".to_string(),
+            "test@example.com".to_string(),
+            "password123",
+        )
+        .await
+        .unwrap();
+
+    let app_state = AppState {
+        storage,
+        oauth_storage,
+        oauth_service,
+    };
+
+    let app = api::create_router(app_state);
+    let token = common::generate_test_token();
+    (app, temp_dir, token)
+}
+
+async fn body_to_bytes(body: Body) -> Bytes {
+    body.collect().await.unwrap().to_bytes()
+}
+
+#[tokio::test]
+async fn test_health_check_no_auth_required() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/ping").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = body_to_bytes(response.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "healthy");
+}
+
+#[tokio::test]
+async fn test_put_and_get_file_with_auth() {
+    let (app, _temp, token) = setup_test_app().await;
+
+    let content = b"Hello, World!";
+
+    // PUT with auth
+    let put_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/test.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::from(content.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(put_response.status(), StatusCode::CREATED);
+
+    // GET with auth
+    let get_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    assert_eq!(
+        get_response.headers().get("content-type").unwrap(),
+        "application/octet-stream"
+    );
+
+    let body = body_to_bytes(get_response.into_body()).await;
+    assert_eq!(body.as_ref(), content);
+}
+
+#[tokio::test]
+async fn test_put_without_auth_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/test.txt")
+                .body(Body::from(b"data".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_get_without_auth_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test.txt")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_head_without_auth_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri("/test.txt")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_delete_without_auth_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/test.txt")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_create_directory_without_auth_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/test_dir")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_invalid_token_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test.txt")
+                .header(header::AUTHORIZATION, "Bearer invalid_token_here")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_expired_token_returns_401() {
+    let (app, _temp, _token) = setup_test_app().await;
+    let expired_token = common::generate_test_token_with_options(
+        "test-user-id",
+        "test-client",
+        vec!["read", "write"],
+        true, // expired
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", expired_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_full_crud_with_auth() {
+    let (app, _temp, token) = setup_test_app().await;
+
+    // Create directory
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/test_dir")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Create file in directory
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/test_dir/file.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::from(b"content".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    // Read file
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/test_dir/file.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Get metadata
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri("/test_dir/file.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Delete file
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/test_dir/file.txt")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Delete directory
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/test_dir")
+                .header(header::AUTHORIZATION, format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}


### PR DESCRIPTION
Transitions API authentication from a global middleware to a per-handler Axum extractor.

Introduces `AuthenticatedUser` to simplify access to verified user details (ID, client, scopes) within handlers. This makes authentication requirements explicit for each route.

Removes the deprecated `auth_middleware` and integrates token verification directly into the `AuthenticatedUser` extractor.

Expands integration test coverage to validate authenticated and unauthenticated access, including handling of invalid and expired tokens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced JWT Bearer authentication for protected file operations (GET, PUT, POST directory, DELETE, HEAD).
  - Clients must include an Authorization: Bearer <token> header for these endpoints.
  - Requests with missing, invalid, or expired tokens now return 401 Unauthorized.
  - Health check endpoint remains publicly accessible without authentication.

- Tests
  - Added comprehensive integration tests covering authenticated and unauthenticated flows, including full CRUD operations and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->