### PR TITLE
Enhances JWT authenticated user extraction

### DIFF
--- a/server/src/api/auth_extractor.rs
+++ b/server/src/api/auth_extractor.rs
@@ -1,5 +1,4 @@
-#[allow(unused_imports)]
-// Claims is used implicitly when accessing fields of verify_access_token's result
+#[cfg(test)]
 use crate::oauth::auth::Claims;
 use axum::{
     async_trait,
@@ -430,20 +429,23 @@ mod tests {
 
         let (mut parts, _) = request.into_parts();
         let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
-        
+
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
 
         // Test with multiple trailing parts
         let request = Request::builder()
             .uri("/test")
-            .header(header::AUTHORIZATION, format!("Bearer {} more garbage", token))
+            .header(
+                header::AUTHORIZATION,
+                format!("Bearer {} more garbage", token),
+            )
             .body(())
             .unwrap();
 
         let (mut parts, _) = request.into_parts();
         let result = AuthenticatedUser::from_request_parts(&mut parts, &state).await;
-        
+
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), StatusCode::UNAUTHORIZED);
     }


### PR DESCRIPTION
Improves the robustness and security of `AuthenticatedUser` extraction from incoming requests.

Refines Authorization header parsing to be case-insensitive for the "Bearer" scheme and properly handles leading/trailing whitespace around the token. It also explicitly rejects empty tokens after the scheme.

Enforces stricter validation for the `sub` claim by requiring it to be a valid UUID. If parsing the `sub` claim as a UUID fails, the request is unauthorized, preventing the system from processing malformed user identifiers.

Removes a generic `From` implementation to allow for this granular, per-field validation during extraction. Comprehensive unit tests are added to cover these new validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More tolerant Authorization header handling: accepts “Bearer” in any case and trims surrounding whitespace.
- Bug Fixes
  - Rejects empty/whitespace-only tokens, missing space between scheme and token, and trailing garbage after the token.
  - Tokens with invalid user identifiers now correctly return UNAUTHORIZED.
- Tests
  - Expanded coverage for header case variations, extra whitespace, missing space, trailing garbage, and invalid token scenarios.
- Refactor
  - Simplified authentication flow by constructing the authenticated user directly from verified token claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->